### PR TITLE
Advice for adding properties to messages on topics

### DIFF
--- a/code/examples/message_property_set.py
+++ b/code/examples/message_property_set.py
@@ -25,6 +25,10 @@ put_msg_h.properties.set(property_name, message) # Default type is CMQC.MQTYPE_S
 
 pmo = pymqi.PMO(Version=pymqi.CMQC.MQPMO_VERSION_3) # PMO v3 is required properties
 pmo.OriginalMsgHandle = put_msg_h.msg_handle
+# pmo.PubLevel = 9
+# If putting a message onto a topic then 'PubLevel' must also be explicitly set to ensure subscribers can receive the message.
+# Default value on a new pmo is 0; only those subscriptions with the highest SubLevel less than or equal to this value receive this publication.
+# See: https://www.ibm.com/docs/en/ibm-mq/9.2?topic=mqpmo-publevel-mqlong
 
 put_md = pymqi.MD(Version=pymqi.CMQC.MQMD_CURRENT_VERSION)
 


### PR DESCRIPTION
When trying to apply this example to messages being published to topics, we found that messages were never received by subscribers. This was tracked down to the default value for pmo.PubLevel being 0, so it's impossible for a subscriber's SubLevel to be less than or equal to this value. Alternatively - the default value on a new PMO object PubLevel could be updated to match the MQ default value "9".